### PR TITLE
license added to RepositoryCollection

### DIFF
--- a/modes/default.json
+++ b/modes/default.json
@@ -421,6 +421,21 @@
           }
         ]
       },
+      "RepositoryCollection": {
+        "hasSubclass": [],
+        "inputs": [
+          {
+            "id": "http://schema.org/license",
+            "name": "license",
+            "help": "A license document that applies to this content, typically indicated by URL.",
+            "required": true,
+            "multiple": true,
+            "type": [
+              "DataReuseLicense"
+            ]
+          }
+        ]
+      },
       "ScholarlyArticle": {
         "hasSubclass": [],
         "inputs": [


### PR DESCRIPTION
License had to be added underRepositoryCollection and not just Dataset - will display by default in the simple ro-crate mode now.