### PR TITLE
Prefixes added for non schema.org terms

### DIFF
--- a/modes/comprehensive-ldac.json
+++ b/modes/comprehensive-ldac.json
@@ -229,7 +229,7 @@
         },
         {
           "id": "http://purl.org/dc/terms/rightsHolder",
-          "name": "rightsHolder",
+          "name": "dct:rightsHolder",
           "label": "rightsHolder",
           "help": "The person or organisation owning or managing rights over the resource.",
           "required": true,
@@ -381,7 +381,7 @@
         },
         {
           "id": "http://pcdm.org/models#hasMember",
-          "name": "hasMember",
+          "name": "pcdm:hasMember",
           "label": "hasMember",
           "help": "The sub-collections, if any, associated with this collection.",
           "type": [
@@ -412,7 +412,7 @@
         },
         {
           "id": "http://pcdm.org/models#memberOf",
-          "name": "memberOf",
+          "name": "pcdm:memberOf",
           "label": "memberOf",
           "help": "Links from a Repository Object or Collection to a containing Repository Object or Collection.",
           "multiple": true,
@@ -812,7 +812,7 @@
         },
         {
           "id": "http://pcdm.org/models#hasMember",
-          "name": "hasMember",
+          "name": "pcdm:hasMember",
           "label": "hasMember",
           "help": "The sub-collection.",
           "type": [
@@ -948,7 +948,7 @@
         },
         {
           "id": "http://pcdm.org/models#memberOf",
-          "name": "memberOf",
+          "name": "pcdm:memberOf",
           "label": "memberOf",
           "help": "Links from a Repository Object or Collection to a containing Repository Object or Collection.",
           "multiple": true,
@@ -1495,7 +1495,7 @@
       "inputs": [
         {
           "id": "http://www.opengis.net/ont/geosparql#asWKT",
-          "name": "asWKT",
+          "name": "geosparql:asWKT",
           "label": "asWKT",
           "help": "The WKT serialisation of the geometry.",
           "required": true,
@@ -1588,15 +1588,6 @@
           "name": "encodingFormat",
           "label": "encodingFormat",
           "help": "The media type typically expressed using a MIME format.",
-          "type": [
-            "Text"
-          ]
-        },
-        {
-          "id": "https://purl.archive.org/language-data-commons/terms#size",
-          "name": "size",
-          "label": "size",
-          "help": "The size in bytes.",
           "type": [
             "Text"
           ]

--- a/modes/comprehensive-ldac.json
+++ b/modes/comprehensive-ldac.json
@@ -186,6 +186,7 @@
         {
           "id": "http://schema.org/isAccessibleForFree",
           "name": "isAccessibleForFree",
+          "label": "isAccessibleForFree",
           "help": "This is available under an Open Access license.",
           "required": false,
           "multiple": false,
@@ -217,7 +218,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#annotationOf",
-          "name": "annotationOf",
+          "name": "ldac:annotationOf",
+          "label": "annotationOf",
           "help": "This resource contains some kind of description that adds information to the resource it references.",
           "required": false,
           "multiple": true,
@@ -253,6 +255,7 @@
         {
           "id": "http://schema.org/creditText",
           "name": "creditText",
+          "label": "creditText",
           "help": "A free text bibliographic citation for this material, e.g. 'Cite as: Musgrave (2023). Title of work. DOI'.",
           "multiple": true,
           "type": [
@@ -272,6 +275,7 @@
         {
           "id": "http://schema.org/author",
           "name": "author",
+          "label": "author",
           "help": "The person or organisation responsible for creating this collection of data. Authors should be identified using URIs such as ORCiD or ROR.",
           "required": true,
           "type": [
@@ -283,6 +287,7 @@
         {
           "id": "http://schema.org/accountablePerson",
           "name": "accountablePerson",
+          "label": "accountablePerson",
           "help": "The person or organisation who is the data steward for this resource.",
           "required": true,
           "type": [
@@ -294,6 +299,7 @@
         {
           "id": "http://schema.org/publisher",
           "name": "publisher",
+          "label": "publisher",
           "help": "The organisation responsible for releasing this dataset.",
           "required": true,
           "type": [
@@ -304,6 +310,7 @@
         {
           "id": "http://schema.org/funder",
           "name": "funder",
+          "label": "funder",
           "help": "The organisation(s) responsible for funding the creation or collection of this dataset.",
           "type": [
             "Organization"
@@ -313,6 +320,7 @@
         {
           "id": "http://schema.org/citation",
           "name": "citation",
+          "label": "citation",
           "help": "Associated publications.",
           "type": [
             "CreativeWork"
@@ -322,6 +330,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "An abstract of the collection. Include as much detail as possible about the motivation and use of the dataset, including things that we do not yet have properties for.",
           "required": true,
           "type": [
@@ -331,7 +340,7 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#doi",
-          "name": "doi",
+          "name": "ldac:doi",
           "label": "DOI",
           "help": "A Digital Object Identifier, e.g. https://doi.org/10.1000/182.",
           "type": [
@@ -342,6 +351,7 @@
         {
           "id": "http://schema.org/temporalCoverage",
           "name": "temporalCoverage",
+          "label": "temporalCoverage",
           "help": "The range of years of creation for items in this dataset using a slash, e.g. 1900/1945. If there are sub-collections with different coverages put this on the sub-collections not the top-level.",
           "type": [
             "DateTime",
@@ -352,6 +362,7 @@
         {
           "id": "http://schema.org/spatialCoverage",
           "name": "spatialCoverage",
+          "label": "spatialCoverage",
           "help": "The place(s) that are the focus of the content. It is a sub-property of contentLocation intended primarily for more technical and detailed materials. For example, with a dataset, it indicates areas that the dataset describes: a dataset Cape York languages would have spatialCoverage which was the place: the outline of the Cape.",
           "type": [
             "Place"
@@ -361,6 +372,7 @@
         {
           "id": "http://schema.org/hasCollectionProtocol",
           "name": "hasCollectionProtocol",
+          "label": "hasCollectionProtocol",
           "help": "A link to a CollectionProtocol object with (at least) a summary of how resources were selected or elicited for this collection/sub-collection.",
           "type": [
             "CollectionProtocol"
@@ -370,6 +382,7 @@
         {
           "id": "http://pcdm.org/models#hasMember",
           "name": "hasMember",
+          "label": "hasMember",
           "help": "The sub-collections, if any, associated with this collection.",
           "type": [
             "RepositoryCollection"
@@ -379,6 +392,7 @@
         {
           "id": "http://schema.org/hasPart",
           "name": "hasPart",
+          "label": "hasPart",
           "help": "An item or CreativeWork that is part of this item, or CreativeWork (in some sense).",
           "type": [
             "File"
@@ -388,6 +402,7 @@
         {
           "id": "http://schema.org/isPartOf",
           "name": "isPartOf",
+          "label": "isPartOf",
           "help": "An item or CreativeWork that this item, or CreativeWork (in some sense), is part of.",
           "multiple": true,
           "type": [
@@ -398,6 +413,7 @@
         {
           "id": "http://pcdm.org/models#memberOf",
           "name": "memberOf",
+          "label": "memberOf",
           "help": "Links from a Repository Object or Collection to a containing Repository Object or Collection.",
           "multiple": true,
           "type": [
@@ -408,6 +424,7 @@
         {
           "id": "http://schema.org/datePublished",
           "name": "datePublished",
+          "label": "datePublished",
           "help": "The (earliest) date this work was created.",
           "multiple": true,
           "type": [
@@ -416,7 +433,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#annotator",
-          "name": "annotator",
+          "name": "ldac:annotator",
+          "label": "annotator",
           "help": "The participant produced an annotation of this or a related resource.",
           "type": [
             "Person"
@@ -425,7 +443,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#compiler",
-          "name": "compiler",
+          "name": "ldac:compiler",
+          "label": "compiler",
           "help": "This refers to someone who creates a single resource with multiple parts, such as a book of short stories, or a person who produces a corpus of resources, which may be archived separately.",
           "type": [
             "Person"
@@ -434,7 +453,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#consultant",
-          "name": "consultant",
+          "name": "ldac:consultant",
+          "label": "consultant",
           "help": "This term is commonly used by field linguists for the native speakers who work with them in describing and analysing a language. They contribute their expertise in their native language to the resource, although their speech, sign, or writing may not appear directly in the resource. In some parts of the world, the preferred term for this role is 'informant'.",
           "type": [
             "Person"
@@ -443,7 +463,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#dataInputter",
-          "name": "dataInputter",
+          "name": "ldac:dataInputter",
+          "label": "dataInputter",
           "help": "The participant was responsible for entering, re-typing, and/or structuring the data contained in the resource.",
           "type": [
             "Person"
@@ -452,7 +473,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#depositor",
-          "name": "depositor",
+          "name": "ldac:depositor",
+          "label": "depositor",
           "help": "The participant was responsible for depositing the resource in an archive.",
           "type": [
             "Person"
@@ -461,7 +483,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#developer",
-          "name": "developer",
+          "name": "ldac:developer",
+          "label": "developer",
           "help": "A software programmer, designer, or analyst; a designer of a questionnaire or research task.",
           "type": [
             "Person"
@@ -470,7 +493,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#editor",
-          "name": "editor",
+          "name": "ldac:editor",
+          "label": "editor",
           "help": "This role includes anyone whose role was editorial in nature, such as proofreaders, debuggers, testers, etc. It may overlap the Compiler role in some cases.",
           "type": [
             "Person"
@@ -479,7 +503,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#illustrator",
-          "name": "illustrator",
+          "name": "ldac:illustrator",
+          "label": "illustrator",
           "help": "The participant contributed drawings or other illustrations to the resource.",
           "type": [
             "Person"
@@ -488,7 +513,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#interviewee",
-          "name": "interviewee",
+          "name": "ldac:interviewee",
+          "label": "interviewee",
           "help": "The participant was a respondent in an interview.",
           "type": [
             "Person"
@@ -497,7 +523,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#interviewer",
-          "name": "interviewer",
+          "name": "ldac:interviewer",
+          "label": "interviewer",
           "help": "The participant conducted an interview that forms part of the resource.",
           "type": [
             "Person"
@@ -506,7 +533,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#participant",
-          "name": "participant",
+          "name": "ldac:participant",
+          "label": "participant",
           "help": "This role is intended for minor participants such as audience members or other peripherally involved participants in the event. These interlocutors need not have been physically present.",
           "type": [
             "Person"
@@ -515,7 +543,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#performer",
-          "name": "performer",
+          "name": "ldac:performer",
+          "label": "performer",
           "help": "It is recommended that this term be used only for creative participants whose role is not better indicated by a more specific term, such as 'speaker', 'signer', or 'singer'.",
           "type": [
             "Person"
@@ -524,7 +553,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#photographer",
-          "name": "photographer",
+          "name": "ldac:photographer",
+          "label": "photographer",
           "help": "The participant took the photograph, or shot the film, that appears in or constitutes the resource.",
           "type": [
             "Person"
@@ -533,7 +563,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#recorder",
-          "name": "recorder",
+          "name": "ldac:recorder",
+          "label": "recorder",
           "help": "The participant operated the recording machinery used to create the resource.",
           "type": [
             "Person"
@@ -542,7 +573,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#researcher",
-          "name": "researcher",
+          "name": "ldac:researcher",
+          "label": "researcher",
           "help": "The resource was created as part of the participant's research, or the research presents interim or final results from the participant's research.",
           "type": [
             "Person"
@@ -551,7 +583,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#researchParticipant",
-          "name": "researchParticipant",
+          "name": "ldac:researchParticipant",
+          "label": "researchParticipant",
           "help": "The participant acted as a research subject or responded to a questionnaire, the results of which study form the basis of the resource.",
           "type": [
             "Person"
@@ -560,7 +593,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#responder",
-          "name": "responder",
+          "name": "ldac:responder",
+          "label": "responder",
           "help": "This person's voice can be heard (or their words can be read) in the resource, typically saying the language-appropriate equivalent of \"uh-huh\", \"amen\", \"you don't say\", etc. This role is sometimes referred to as a \"yes-sayer\", \"backchanneler\", or \"co-conversant\".",
           "type": [
             "Person"
@@ -569,7 +603,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#signer",
-          "name": "signer",
+          "name": "ldac:signer",
+          "label": "signer",
           "help": "Those whose gestures predominate in a recorded or filmed resource. (This resource may be a transcription of that recording).",
           "type": [
             "Person"
@@ -578,7 +613,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#singer",
-          "name": "singer",
+          "name": "ldac:singer",
+          "label": "singer",
           "help": "The participant sang, either individually or as part of a group, in a resource that consists of a recording, a film, or a transcription of a recorded resource.",
           "type": [
             "Person"
@@ -587,7 +623,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#speaker",
-          "name": "speaker",
+          "name": "ldac:speaker",
+          "label": "speaker",
           "help": "Those whose voices predominate in a recorded or filmed resource. (This resource may be a transcription of that recording).",
           "type": [
             "Person"
@@ -596,7 +633,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#sponsor",
-          "name": "sponsor",
+          "name": "ldac:sponsor",
+          "label": "sponsor",
           "help": "The participant contributed financial support to the creation of the resource.",
           "type": [
             "Person"
@@ -605,7 +643,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#transcriber",
-          "name": "transcriber",
+          "name": "ldac:transcriber",
+          "label": "transcriber",
           "help": "The participant produced a transcription of this or a related resource.",
           "type": [
             "Person"
@@ -614,7 +653,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#translator",
-          "name": "translator",
+          "name": "ldac:translator",
+          "label": "translator",
           "help": "The participant produced a translation of this or a related resource.",
           "type": [
             "Person"
@@ -629,6 +669,7 @@
         {
           "id": "http://schema.org/contentLocation",
           "name": "contentLocation",
+          "label": "contentLocation",
           "help": "The location depicted or described in the content. For example, the location in a photograph or painting.",
           "type": [
             "Place"
@@ -638,13 +679,14 @@
         {
           "id": "http://purl.org/dc/terms/conformsTo",
           "name": "conformsTo",
+          "label": "conformsTo",
           "help": "A link to the Text Commons RO-Crate profile for collections.",
           "type": [
             "Select"
           ],
           "values": [
             {
-              "@id": "https://purl.archive.org/language-data-commons/profile#Collection"
+              "@id": "https://w3id.org/ldac/profile#Collection"
             }
           ],
           "multiple": false
@@ -662,7 +704,7 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#subjectLanguage",
-          "name": "subjectLanguage",
+          "name": "ldac:subjectLanguage",
           "label": "subjectLanguage",
           "help": "The languages that the materials in the collection are about (not the language that it is in).",
           "type": [
@@ -685,6 +727,7 @@
         {
           "id": "http://schema.org/author",
           "name": "author",
+          "label": "author",
           "help": "The person or organisation responsible for creating this collection of data. Authors should be identified using URIs such as ORCiD or ROR.",
           "type": [
             "Person",
@@ -695,6 +738,7 @@
         {
           "id": "http://schema.org/accountablePerson",
           "name": "accountablePerson",
+          "label": "accountablePerson",
           "help": "The person or organisation who is the data steward for this resource.",
           "required": true,
           "type": [
@@ -706,6 +750,7 @@
         {
           "id": "http://schema.org/funder",
           "name": "funder",
+          "label": "funder",
           "help": "The organisation(s) responsible for funding the creation or collection of this data.",
           "type": [
             "Organization"
@@ -715,6 +760,7 @@
         {
           "id": "http://schema.org/citation",
           "name": "citation",
+          "label": "citation",
           "help": "Associated publications.",
           "type": [
             "CreativeWork"
@@ -736,6 +782,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "A description of the collection.",
           "type": [
             "TextArea"
@@ -745,6 +792,7 @@
         {
           "id": "http://schema.org/temporalCoverage",
           "name": "temporalCoverage",
+          "label": "temporalCoverage",
           "help": "The range of years of creation for items in this collection using a slash, e.g. 1900/1945. If there are sub-collections with different coverages put this on the sub-collections not the top-level.",
           "type": [
             "DateTime",
@@ -755,6 +803,7 @@
         {
           "id": "http://schema.org/hasCollectionProtocol",
           "name": "hasCollectionProtocol",
+          "label": "hasCollectionProtocol",
           "help": "A link to a CollectionProtocol object with (at least) a summary of how resources were selected or elicited for this collection/sub-collection.",
           "type": [
             "CollectionProtocol"
@@ -764,6 +813,7 @@
         {
           "id": "http://pcdm.org/models#hasMember",
           "name": "hasMember",
+          "label": "hasMember",
           "help": "The sub-collection.",
           "type": [
             "RepositoryCollection"
@@ -773,6 +823,7 @@
         {
           "id": "http://schema.org/dateCreated",
           "name": "dateCreated",
+          "label": "dateCreated",
           "help": "The (earliest) date the data in this dataset were created.",
           "type": [
             "Date"
@@ -781,7 +832,8 @@
         }, 
         {
           "id": "https://w3id.org/ldac/terms#dateFreeText",
-          "name": "dateFreeText",
+          "name": "ldac:dateFreeText",
+          "label": "dateFreeText",
           "help": "Date information which cannot be put in one of the standard date formats, e.g. 'mid-1970s', or it is not clear, for example, if it is a creation or publication date.",
           "type": [
             "Text"
@@ -817,6 +869,7 @@
         {
           "id": "http://schema.org/hasPart",
           "name": "hasPart",
+          "label": "hasPart",
           "help": "An item or CreativeWork that is part of this item, or CreativeWork (in some sense).",
           "multiple": true,
           "type": [
@@ -826,6 +879,7 @@
         {
           "id": "http://purl.org/dc/terms/conformsTo",
           "name": "conformsTo",
+          "label": "conformsTo",
           "help": "A link to the Text Commons RO-Crate profile for collections.",
           "multiple": true,
           "type": [
@@ -835,6 +889,7 @@
         {
           "id": "http://schema.org/publisher",
           "name": "publisher",
+          "label": "publisher",
           "help": "The publisher of the creative work.",
           "multiple": true,
           "type": [
@@ -844,6 +899,7 @@
         {
           "id": "http://schema.org/creator",
           "name": "creator",
+          "label": "creator",
           "help": "The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.",
           "multiple": true,
           "type": [
@@ -852,7 +908,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#compiler",
-          "name": "compiler",
+          "name": "ldac:compiler",
+          "label": "compiler",
           "help": "The contributor responsible for collecting the sub-parts of the resource together.",
           "multiple": true,
           "type": [
@@ -862,6 +919,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "A description of the item.",
           "multiple": true,
           "type": [
@@ -871,6 +929,7 @@
         {
           "id": "http://schema.org/datePublished",
           "name": "datePublished",
+          "label": "datePublished",
           "help": "The (earliest) date this work was created.",
           "multiple": true,
           "type": [
@@ -880,6 +939,7 @@
         {
           "id": "http://schema.org/temporalCoverage",
           "name": "temporalCoverage",
+          "label": "temporalCoverage",
           "help": "The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals). In\n      the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written \"2011/2012\"). Other forms of content, e.g. ScholarlyArticle, Book, TVSeries or TVEpisode, may indicate their temporalCoverage in broader terms - textually or via well-known URL.\n      Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via \"1939/1945\".\n\nOpen-ended date ranges can be written with \"..\" in place of the end date. For example, \"2015-11/..\" indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.",
           "multiple": true,
           "type": [
@@ -889,6 +949,7 @@
         {
           "id": "http://pcdm.org/models#memberOf",
           "name": "memberOf",
+          "label": "memberOf",
           "help": "Links from a Repository Object or Collection to a containing Repository Object or Collection.",
           "multiple": true,
           "type": [
@@ -899,6 +960,7 @@
         {
           "id": "http://schema.org/inLanguage",
           "name": "inLanguage",
+          "label": "inLanguage",
           "help": "The language in which the resource is written.",
           "multiple": true,
           "type": [
@@ -907,7 +969,7 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#subjectLanguage",
-          "name": "subjectLanguage",
+          "name": "ldac:subjectLanguage",
           "label": "subjectLanguage",
           "help": "The languages that the materials in the collection are about (not the language that it is in).",
           "type": [
@@ -918,6 +980,7 @@
         {
           "id": "http://schema.org/dateCreated",
           "name": "dateCreated",
+          "label": "dateCreated",
           "help": "The date on which the CreativeWork was created or the item was added to a DataFeed.",
           "multiple": true,
           "type": [
@@ -927,6 +990,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
+          "label": "name",
           "help": "The name of the item.",
           "multiple": true,
           "type": [
@@ -936,6 +1000,7 @@
         {
           "id": "http://schema.org/license",
           "name": "license",
+          "label": "license",
           "help": "A license document that applies to this content, typically indicated by URL.",
           "multiple": true,
           "type": [
@@ -944,7 +1009,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#hasAnnotation",
-          "name": "hasAnnotation",
+          "name": "ldac:hasAnnotation",
+          "label": "hasAnnotation",
           "help": "This resource is referenced by another resource that adds information to it such as a translation, transcription or other analysis.",
           "multiple": true,
           "type": [
@@ -953,7 +1019,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#annotator",
-          "name": "annotator",
+          "name": "ldac:annotator",
+          "label": "annotator",
           "help": "The participant produced an annotation of this or a related resource.",
           "type": [
             "Person"
@@ -963,6 +1030,7 @@
         {
           "id": "http://schema.org/author",
           "name": "author",
+          "label": "author",
           "help": "The person or organisation responsible for creating this work. Authors should be identified using URIs such as ORCiD or ROR.",
           "type": [
             "Person",
@@ -972,7 +1040,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#compiler",
-          "name": "compiler",
+          "name": "ldac:compiler",
+          "label": "compiler",
           "help": "This refers to someone who creates a single resource with multiple parts, such as a book of short stories, or a person who produces a corpus of resources, which may be archived separately.",
           "type": [
             "Person"
@@ -981,7 +1050,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#consultant",
-          "name": "consultant",
+          "name": "ldac:consultant",
+          "label": "consultant",
           "help": "This term is commonly used by field linguists for the native speakers who work with them in describing and analysing a language. They contribute their expertise in their native language to the resource, although their speech, sign, or writing may not appear directly in the resource. In some parts of the world, the preferred term for this role is 'informant'.",
           "type": [
             "Person"
@@ -990,7 +1060,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#dataInputter",
-          "name": "dataInputter",
+          "name": "ldac:dataInputter",
+          "label": "dataInputter",
           "help": "The participant was responsible for entering, re-typing, and/or structuring the data contained in the resource.",
           "type": [
             "Person"
@@ -999,7 +1070,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#depositor",
-          "name": "depositor",
+          "name": "ldac:depositor",
+          "label": "depositor",
           "help": "The participant was responsible for depositing the resource in an archive.",
           "type": [
             "Person"
@@ -1008,7 +1080,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#developer",
-          "name": "developer",
+          "name": "ldac:developer",
+          "label": "developer",
           "help": "A software programmer, designer, or analyst; a designer of a questionnaire or research task.",
           "type": [
             "Person"
@@ -1017,7 +1090,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#editor",
-          "name": "editor",
+          "name": "ldac:editor",
+          "label": "editor",
           "help": "This role includes anyone whose role was editorial in nature, such as proofreaders, debuggers, testers, etc. It may overlap the Compiler role in some cases.",
           "type": [
             "Person"
@@ -1026,7 +1100,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#illustrator",
-          "name": "illustrator",
+          "name": "ldac:illustrator",
+          "label": "illustrator",
           "help": "The participant contributed drawings or other illustrations to the resource.",
           "type": [
             "Person"
@@ -1035,7 +1110,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#interviewee",
-          "name": "interviewee",
+          "name": "ldac:interviewee",
+          "label": "interviewee",
           "help": "The participant was a respondent in an interview.",
           "type": [
             "Person"
@@ -1044,7 +1120,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#interviewer",
-          "name": "interviewer",
+          "name": "ldac:interviewer",
+          "label": "interviewer",
           "help": "The participant conducted an interview that forms part of the resource.",
           "type": [
             "Person"
@@ -1053,7 +1130,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#participant",
-          "name": "participant",
+          "name": "ldac:participant",
+          "label": "participant",
           "help": "This role is intended for minor participants such as audience members or other peripherally involved participants in the event. These interlocutors need not have been physically present.",
           "type": [
             "Person"
@@ -1062,7 +1140,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#performer",
-          "name": "performer",
+          "name": "ldac:performer",
+          "label": "performer",
           "help": "It is recommended that this term be used only for creative participants whose role is not better indicated by a more specific term, such as 'speaker', 'signer', or 'singer'.",
           "type": [
             "Person"
@@ -1071,7 +1150,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#photographer",
-          "name": "photographer",
+          "name": "ldac:photographer",
+          "label": "photographer",
           "help": "The participant took the photograph, or shot the film, that appears in or constitutes the resource.",
           "type": [
             "Person"
@@ -1080,7 +1160,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#recorder",
-          "name": "recorder",
+          "name": "ldac:recorder",
+          "label": "recorder",
           "help": "The participant operated the recording machinery used to create the resource.",
           "type": [
             "Person"
@@ -1089,7 +1170,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#researcher",
-          "name": "researcher",
+          "name": "ldac:researcher",
+          "label": "researcher",
           "help": "The resource was created as part of the participant's research, or the research presents interim or final results from the participant's research.",
           "type": [
             "Person"
@@ -1098,7 +1180,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#researchParticipant",
-          "name": "researchParticipant",
+          "name": "ldac:researchParticipant",
+          "label": "researchParticipant",
           "help": "The participant acted as a research subject or responded to a questionnaire, the results of which study form the basis of the resource.",
           "type": [
             "Person"
@@ -1107,7 +1190,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#responder",
-          "name": "responder",
+          "name": "ldac:responder",
+          "label": "responder",
           "help": "This person's voice can be heard (or their words can be read) in the resource, typically saying the language-appropriate equivalent of \"uh-huh\", \"amen\", \"you don't say\", etc. This role is sometimes referred to as a \"yes-sayer\", \"backchanneler\", or \"co-conversant\".",
           "type": [
             "Person"
@@ -1116,7 +1200,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#signer",
-          "name": "signer",
+          "name": "ldac:signer",
+          "label": "signer",
           "help": "Those whose gestures predominate in a recorded or filmed resource. (This resource may be a transcription of that recording).",
           "type": [
             "Person"
@@ -1125,7 +1210,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#singer",
-          "name": "singer",
+          "name": "ldac:singer",
+          "label": "singer",
           "help": "The participant sang, either individually or as part of a group, in a resource that consists of a recording, a film, or a transcription of a recorded resource.",
           "type": [
             "Person"
@@ -1134,7 +1220,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#speaker",
-          "name": "speaker",
+          "name": "ldac:speaker",
+          "label": "speaker",
           "help": "Those whose voices predominate in a recorded or filmed resource. (This resource may be a transcription of that recording).",
           "type": [
             "Person"
@@ -1143,7 +1230,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#sponsor",
-          "name": "sponsor",
+          "name": "ldac:sponsor",
+          "label": "sponsor",
           "help": "The participant contributed financial support to the creation of the resource.",
           "type": [
             "Person"
@@ -1152,7 +1240,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#transcriber",
-          "name": "transcriber",
+          "name": "ldac:transcriber",
+          "label": "transcriber",
           "help": "The participant produced a transcription of this or a related resource.",
           "type": [
             "Person"
@@ -1161,7 +1250,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#translator",
-          "name": "translator",
+          "name": "ldac:translator",
+          "label": "translator",
           "help": "The participant produced a translation of this or a related resource.",
           "type": [
             "Person"
@@ -1171,6 +1261,7 @@
         {
           "id": "http://schema.org/identifier",
           "name": "identifier",
+          "label": "identifier",
           "help": "The identifier property represents any kind of identifier for any kind of [[Thing]], such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.\n        ",
           "multiple": true,
           "type": [
@@ -1196,6 +1287,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "An abstract of the work.",
           "type": [
             "TextArea"
@@ -1205,6 +1297,7 @@
         {
           "id": "http://schema.org/author",
           "name": "author",
+          "label": "author",
           "help": "The person or organisation responsible for creating this work. Authors should be identified using URIs such as ORCiD or ROR.",
           "type": [
             "Text",
@@ -1216,6 +1309,7 @@
         {
           "id": "http://schema.org/recipient",
           "name": "recipient",
+          "label": "recipient",
           "help": "The person or organisation responsible for creating this work. Authors should be identified using URIs such as ORCiD or ROR.",
           "type": [
             "Text",
@@ -1227,6 +1321,7 @@
         {
           "id": "http://schema.org/datePublished",
           "name": "datePublished",
+          "label": "datePublished",
           "help": "The (earliest) date this work was created.",
           "type": [
             "Text"
@@ -1237,6 +1332,7 @@
         {
           "id": "http://schema.org/publisher",
           "name": "publisher",
+          "label": "publisher",
           "help": "The organisation that published this work.",
           "type": [
             "Text",
@@ -1247,6 +1343,7 @@
         {
           "id": "http://schema.org/isbn",
           "name": "isbn",
+          "label": "ISBN",
           "help": "The ISBN for this work, if applicable.",
           "type": [
             "Text"
@@ -1256,6 +1353,7 @@
         {
           "id": "http://schema.org/issn",
           "name": "issn",
+          "label": "ISSN",
           "help": "The ISSN for this publication.",
           "type": [
             "Text"
@@ -1281,6 +1379,7 @@
         {
           "id": "http://schema.org/author",
           "name": "author",
+          "label": "author",
           "help": "The person or organisation responsible for creating this collection of data. Authors should be identified using URIs such as ORCiD or ROR.",
           "required": true,
           "type": [
@@ -1292,6 +1391,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "A summary of the collection protocol used for this collection or sub-collection, e.g. how texts were selected, or what prompts were given to participants.",
           "type": [
             "TextArea"
@@ -1300,7 +1400,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#collectionProtocolType",
-          "name": "collectionProtocolType",
+          "name": "ldac:collectionProtocolType",
+          "label": "collectionProtocolType",
           "help": "A description of the process used to collect or collate data, such as prompts given to participants, or how texts are selected for inclusion in a collection.",
           "type": [
             "SelectObject"
@@ -1330,6 +1431,7 @@
         {
           "id": "http://schema.org/datePublished",
           "name": "datePublished",
+          "label": "datePublished",
           "help": "The (earliest) date the collection protocol was published.",
           "type": [
             "Date"
@@ -1345,6 +1447,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
+          "label": "name",
           "help": "The name of the place.",
           "required": true,
           "multiple": false,
@@ -1355,6 +1458,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "A description of the place.",
           "multiple": false,
           "type": [
@@ -1364,6 +1468,7 @@
         {
           "id": "http://schema.org/address",
           "name": "address",
+          "label": "address",
           "help": "The physical address of the place.",
           "required": false,
           "multiple": true,
@@ -1374,6 +1479,7 @@
         {
           "id": "http://schema.org/geo",
           "name": "geo",
+          "label": "geo",
           "help": "The geographic coordinates of the place.",
           "required": false,
           "multiple": true,
@@ -1390,6 +1496,7 @@
         {
           "id": "http://www.opengis.net/ont/geosparql#asWKT",
           "name": "asWKT",
+          "label": "asWKT",
           "help": "The WKT serialisation of the geometry.",
           "required": true,
           "multiple": true,
@@ -1417,6 +1524,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "Add any additional information not covered by other properties here.",
           "type": [
             "TextArea"
@@ -1453,6 +1561,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "A description of the organisation.",
           "type": [
             "TextArea"
@@ -1462,6 +1571,7 @@
         {
           "id": "http://schema.org/location",
           "name": "location",
+          "label": "location",
           "help": "A location for the organisation, e.g. a city for a publisher.",
           "type": [
             "Text"
@@ -1476,6 +1586,7 @@
         {
           "id": "http://schema.org/encodingFormat",
           "name": "encodingFormat",
+          "label": "encodingFormat",
           "help": "The media type typically expressed using a MIME format.",
           "type": [
             "Text"
@@ -1484,6 +1595,7 @@
         {
           "id": "https://purl.archive.org/language-data-commons/terms#size",
           "name": "size",
+          "label": "size",
           "help": "The size in bytes.",
           "type": [
             "Text"
@@ -1491,7 +1603,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#communicationMode",
-          "name": "communicationMode",
+          "name": "ldac:communicationMode",
+          "label": "communicationMode",
           "help": "The mode(s) (spoken, written, signed, etc.) used in the interaction represented by this resource.",
           "type": [
             "SelectObject"
@@ -1556,6 +1669,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
+          "label": "name",
           "help": "The name of the item.",
           "multiple": true,
           "type": [
@@ -1565,6 +1679,7 @@
         {
           "id": "http://schema.org/license",
           "name": "license",
+          "label": "license",
           "help": "A license document that applies to this content, typically indicated by URL.",
           "multiple": true,
           "type": [
@@ -1573,7 +1688,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#linguisticGenre",
-          "name": "linguisticGenre",
+          "name": "ldac:linguisticGenre",
+          "label": "linguisticGenre",
           "help": "A linguistic classification of the genre of this resource.",
           "multiple": true,
           "type": [
@@ -1693,6 +1809,7 @@
         {
           "id": "http://schema.org/contentSize",
           "name": "contentSize",
+          "label": "contentSize",
           "help": "File size in (mega/kilo)bytes.",
           "multiple": true,
           "type": [
@@ -1702,6 +1819,7 @@
         {
           "id": "http://schema.org/hasPart",
           "name": "hasPart",
+          "label": "hasPart",
           "help": "An item or CreativeWork that is part of this item, or CreativeWork (in some sense).",
           "multiple": true,
           "type": [
@@ -1711,6 +1829,7 @@
         {
           "id": "http://schema.org/publisher",
           "name": "publisher",
+          "label": "publisher",
           "help": "The publisher of the creative work.",
           "multiple": true,
           "type": [
@@ -1720,6 +1839,7 @@
         {
           "id": "http://schema.org/creator",
           "name": "creator",
+          "label": "creator",
           "help": "The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.",
           "multiple": true,
           "type": [
@@ -1729,6 +1849,7 @@
         {
           "id": "http://schema.org/datePublished",
           "name": "datePublished",
+          "label": "datePublished",
           "help": "The (earliest) date this work was created..",
           "multiple": true,
           "type": [
@@ -1738,6 +1859,7 @@
         {
           "id": "http://schema.org/temporalCoverage",
           "name": "temporalCoverage",
+          "label": "temporalCoverage",
           "help": "The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals). In\n      the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written \"2011/2012\"). Other forms of content, e.g. ScholarlyArticle, Book, TVSeries or TVEpisode, may indicate their temporalCoverage in broader terms - textually or via well-known URL.\n      Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via \"1939/1945\".\n\nOpen-ended date ranges can be written with \"..\" in place of the end date. For example, \"2015-11/..\" indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.",
           "multiple": true,
           "type": [
@@ -1747,6 +1869,7 @@
         {
           "id": "http://schema.org/inLanguage",
           "name": "inLanguage",
+          "label": "inLanguage",
           "help": "The language in which the resource is written.",
           "multiple": true,
           "type": [
@@ -1755,7 +1878,7 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#subjectLanguage",
-          "name": "subjectLanguage",
+          "name": "ldac:subjectLanguage",
           "label": "subjectLanguage",
           "help": "The languages that the materials in the collection are about (not the language that it is in).",
           "type": [
@@ -1766,6 +1889,7 @@
         {
           "id": "http://schema.org/dateCreated",
           "name": "dateCreated",
+          "label": "dateCreated",
           "help": "The date on which the CreativeWork was created or the item was added to a DataFeed.",
           "multiple": true,
           "type": [
@@ -1774,7 +1898,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#materialType",
-          "name": "materialType",
+          "name": "ldac:materialType",
+          "label": "materialType",
           "help": "Indicates whether the material in a file is the original (primary) source or is derived from it or describes it via annotation.",
           "multiple": true,
           "type": [
@@ -1818,6 +1943,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
+          "label": "name",
           "help": "The name of the item.",
           "multiple": true,
           "type": [
@@ -1827,6 +1953,7 @@
         {
           "id": "http://schema.org/license",
           "name": "license",
+          "label": "license",
           "help": "A license document that applies to this content, typically indicated by URL.",
           "multiple": true,
           "type": [
@@ -1836,6 +1963,7 @@
         {
           "id": "http://schema.org/encodingFormat",
           "name": "encodingFormat",
+          "label": "encodingFormat",
           "help": "The media type typically expressed using a MIME format.",
           "multiple": true,
           "type": [
@@ -1844,7 +1972,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#communicationMode",
-          "name": "communicationMode",
+          "name": "ldac:communicationMode",
+          "label": "communicationMode",
           "help": "The mode (spoken, written, signed etc.) of this resource. There may be more than one value for this property.",
           "multiple": true,
           "type": [
@@ -1909,7 +2038,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#linguisticGenre",
-          "name": "linguisticGenre",
+          "name": "ldac:linguisticGenre",
+          "label": "linguisticGenre",
           "help": "A linguistic classification of the genre of this resource.",
           "multiple": true,
           "type": [
@@ -2028,7 +2158,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#annotationType",
-          "name": "annotationType",
+          "name": "ldac:annotationType",
+          "label": "annotationType",
           "help": "Specifies the type of an Annotation resource.",
           "multiple": true,
           "type": [
@@ -2038,6 +2169,7 @@
         {
           "id": "http://schema.org/size",
           "name": "size",
+          "label": "size",
           "help": "The size in bytes.",
           "multiple": true,
           "type": [

--- a/modes/comprehensive-ldac.json
+++ b/modes/comprehensive-ldac.json
@@ -197,7 +197,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
-          "label": "Name",
+          "label": "name",
           "help": "The name of this dataset.",
           "required": true,
           "multiple": false,
@@ -231,7 +231,7 @@
           "id": "http://purl.org/dc/terms/rightsHolder",
           "name": "rightsHolder",
           "label": "rightsHolder",
-          "help": "A person or organisation owning or managing rights over the resource.",
+          "help": "The person or organisation owning or managing rights over the resource.",
           "required": true,
           "multiple": false,
           "type": [
@@ -445,7 +445,7 @@
           "id": "https://w3id.org/ldac/terms#compiler",
           "name": "ldac:compiler",
           "label": "compiler",
-          "help": "This refers to someone who creates a single resource with multiple parts, such as a book of short stories, or a person who produces a corpus of resources, which may be archived separately.",
+          "help": "The person who creates a single resource with multiple parts, such as a book of short stories, or who produces a corpus of resources, which may be archived separately.",
           "type": [
             "Person"
           ],
@@ -455,7 +455,7 @@
           "id": "https://w3id.org/ldac/terms#consultant",
           "name": "ldac:consultant",
           "label": "consultant",
-          "help": "This term is commonly used by field linguists for the native speakers who work with them in describing and analysing a language. They contribute their expertise in their native language to the resource, although their speech, sign, or writing may not appear directly in the resource. In some parts of the world, the preferred term for this role is 'informant'.",
+          "help": "Commonly used by field linguists for the native speakers who work with them in describing and analysing a language. They contribute their expertise in their native language to the resource, although their speech, sign, or writing may not appear directly in the resource. In some parts of the world, the preferred term for this role is 'informant'.",
           "type": [
             "Person"
           ],
@@ -465,7 +465,7 @@
           "id": "https://w3id.org/ldac/terms#dataInputter",
           "name": "ldac:dataInputter",
           "label": "dataInputter",
-          "help": "The participant was responsible for entering, re-typing, and/or structuring the data contained in the resource.",
+          "help": "The participant responsible for entering, re-typing, and/or structuring the data contained in the resource.",
           "type": [
             "Person"
           ],
@@ -475,7 +475,7 @@
           "id": "https://w3id.org/ldac/terms#depositor",
           "name": "ldac:depositor",
           "label": "depositor",
-          "help": "The participant was responsible for depositing the resource in an archive.",
+          "help": "The participant responsible for depositing the resource in an archive.",
           "type": [
             "Person"
           ],
@@ -495,7 +495,7 @@
           "id": "https://w3id.org/ldac/terms#editor",
           "name": "ldac:editor",
           "label": "editor",
-          "help": "This role includes anyone whose role was editorial in nature, such as proofreaders, debuggers, testers, etc. It may overlap the Compiler role in some cases.",
+          "help": "Anyone whose role was editorial in nature, such as proofreaders, debuggers, testers, etc. It may overlap the Compiler role in some cases.",
           "type": [
             "Person"
           ],
@@ -535,7 +535,7 @@
           "id": "https://w3id.org/ldac/terms#participant",
           "name": "ldac:participant",
           "label": "participant",
-          "help": "This role is intended for minor participants such as audience members or other peripherally involved participants in the event. These interlocutors need not have been physically present.",
+          "help": "Minor participants such as audience members or other peripherally involved participants in the event. These interlocutors need not have been physically present.",
           "type": [
             "Person"
           ],
@@ -680,7 +680,7 @@
           "id": "http://purl.org/dc/terms/conformsTo",
           "name": "conformsTo",
           "label": "conformsTo",
-          "help": "A link to the Text Commons RO-Crate profile for collections.",
+          "help": "A link to the language data commons RO-Crate profile for collections.",
           "type": [
             "Select"
           ],
@@ -716,7 +716,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
-          "label": "Name",
+          "label": "name",
           "help": "The name of this collection.",
           "required": true,
           "multiple": false,
@@ -843,7 +843,7 @@
         {
           "id": "http://schema.org/holdingArchive",
           "name": "holdingArchive",
-          "label": "HoldingArchive",
+          "label": "holdingArchive",
           "help": "Organisation where the original of this work or collection is housed.",
           "multiple": false,
           "type": [
@@ -880,7 +880,7 @@
           "id": "http://purl.org/dc/terms/conformsTo",
           "name": "conformsTo",
           "label": "conformsTo",
-          "help": "A link to the Text Commons RO-Crate profile for collections.",
+          "help": "A link to the language data commons RO-Crate profile for collections.",
           "multiple": true,
           "type": [
             "Text"
@@ -1042,7 +1042,7 @@
           "id": "https://w3id.org/ldac/terms#compiler",
           "name": "ldac:compiler",
           "label": "compiler",
-          "help": "This refers to someone who creates a single resource with multiple parts, such as a book of short stories, or a person who produces a corpus of resources, which may be archived separately.",
+          "help": "The person who creates a single resource with multiple parts, such as a book of short stories, or who produces a corpus of resources, which may be archived separately.",
           "type": [
             "Person"
           ],
@@ -1052,7 +1052,7 @@
           "id": "https://w3id.org/ldac/terms#consultant",
           "name": "ldac:consultant",
           "label": "consultant",
-          "help": "This term is commonly used by field linguists for the native speakers who work with them in describing and analysing a language. They contribute their expertise in their native language to the resource, although their speech, sign, or writing may not appear directly in the resource. In some parts of the world, the preferred term for this role is 'informant'.",
+          "help": "Commonly used by field linguists for the native speakers who work with them in describing and analysing a language. They contribute their expertise in their native language to the resource, although their speech, sign, or writing may not appear directly in the resource. In some parts of the world, the preferred term for this role is 'informant'.",
           "type": [
             "Person"
           ],
@@ -1062,7 +1062,7 @@
           "id": "https://w3id.org/ldac/terms#dataInputter",
           "name": "ldac:dataInputter",
           "label": "dataInputter",
-          "help": "The participant was responsible for entering, re-typing, and/or structuring the data contained in the resource.",
+          "help": "The participant responsible for entering, re-typing, and/or structuring the data contained in the resource.",
           "type": [
             "Person"
           ],
@@ -1072,7 +1072,7 @@
           "id": "https://w3id.org/ldac/terms#depositor",
           "name": "ldac:depositor",
           "label": "depositor",
-          "help": "The participant was responsible for depositing the resource in an archive.",
+          "help": "The participant responsible for depositing the resource in an archive.",
           "type": [
             "Person"
           ],
@@ -1092,7 +1092,7 @@
           "id": "https://w3id.org/ldac/terms#editor",
           "name": "ldac:editor",
           "label": "editor",
-          "help": "This role includes anyone whose role was editorial in nature, such as proofreaders, debuggers, testers, etc. It may overlap the Compiler role in some cases.",
+          "help": "Anyone whose role was editorial in nature, such as proofreaders, debuggers, testers, etc. It may overlap the Compiler role in some cases.",
           "type": [
             "Person"
           ],
@@ -1132,7 +1132,7 @@
           "id": "https://w3id.org/ldac/terms#participant",
           "name": "ldac:participant",
           "label": "participant",
-          "help": "This role is intended for minor participants such as audience members or other peripherally involved participants in the event. These interlocutors need not have been physically present.",
+          "help": "Minor participants such as audience members or other peripherally involved participants in the event. These interlocutors need not have been physically present.",
           "type": [
             "Person"
           ],
@@ -1276,7 +1276,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
-          "label": "Name",
+          "label": "name",
           "help": "The name of this work.",
           "required": true,
           "multiple": false,
@@ -1368,7 +1368,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
-          "label": "Name",
+          "label": "name",
           "help": "The name of this protocol.",
           "required": true,
           "multiple": false,

--- a/modes/default.json
+++ b/modes/default.json
@@ -370,7 +370,7 @@
             "help": "The subject matter of the content.",
             "multiple": true,
             "type": [
-              "Dataset"
+              "Text"
             ]
           },
           {
@@ -836,7 +836,7 @@
             "help": "The subject matter of the content.",
             "multiple": true,
             "type": [
-              "Dataset"
+              "Text"
             ]
           },
           {
@@ -1158,7 +1158,7 @@
             "help": "The subject matter of the content.",
             "multiple": true,
             "type": [
-              "Dataset"
+              "Text"
             ]
           },
           {

--- a/modes/default.json
+++ b/modes/default.json
@@ -96,7 +96,7 @@
           },
           {
             "id": "http://pcdm.org/models#hasMember",
-            "name": "hasMember",
+            "name": "pcdm:hasMember",
             "help": "The sub-collections, if any, associated with this collection.",
             "type": [
               "RepositoryCollection"
@@ -125,7 +125,7 @@
           },
           {
             "id": "http://pcdm.org/models#memberOf",
-            "name": "memberOf",
+            "name": "pcdm:memberOf",
             "help": "Links from a Repository Object or Collection to a containing Repository Object or Collection.",
             "multiple": true,
             "type": [
@@ -956,7 +956,7 @@
         "inputs": [
           {
             "id": "http://www.opengis.net/ont/geosparql#asWKT",
-            "name": "asWKT",
+            "name": "geosparql:asWKT",
             "help": "The WKT serialisation of the geometry.",
             "required": true,
             "multiple": true,

--- a/modes/language-data-commons-collection.json
+++ b/modes/language-data-commons-collection.json
@@ -195,7 +195,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
-          "label": "Name",
+          "label": "name",
           "help": "The name of this dataset.",
           "required": true,
           "multiple": false,
@@ -229,7 +229,7 @@
           "id": "http://purl.org/dc/terms/rightsHolder",
           "name": "rightsHolder",
           "label": "rightsHolder",
-          "help": "A person or organisation owning or managing rights over the resource.",
+          "help": "The person or organisation owning or managing rights over the resource.",
           "required": true,
           "multiple": false,
           "type": [
@@ -433,7 +433,7 @@
           "id": "https://w3id.org/ldac/terms#compiler",
           "name": "ldac:compiler",
           "label": "compiler",
-          "help": "This refers to someone who creates a single resource with multiple parts, such as a book of short stories, or a person who produces a corpus of resources, which may be archived separately.",
+          "help": "The person who creates a single resource with multiple parts, such as a book of short stories, or who produces a corpus of resources, which may be archived separately.",
           "type": [
             "Person"
           ],
@@ -443,7 +443,7 @@
           "id": "https://w3id.org/ldac/terms#consultant",
           "name": "ldac:consultant",
           "label": "consultant",
-          "help": "This term is commonly used by field linguists for the native speakers who work with them in describing and analysing a language. They contribute their expertise in their native language to the resource, although their speech, sign, or writing may not appear directly in the resource. In some parts of the world, the preferred term for this role is 'informant'.",
+          "help": "Commonly used by field linguists for the native speakers who work with them in describing and analysing a language. They contribute their expertise in their native language to the resource, although their speech, sign, or writing may not appear directly in the resource. In some parts of the world, the preferred term for this role is 'informant'.",
           "type": [
             "Person"
           ],
@@ -453,7 +453,7 @@
           "id": "https://w3id.org/ldac/terms#dataInputter",
           "name": "ldac:dataInputter",
           "label": "dataInputter",
-          "help": "The participant was responsible for entering, re-typing, and/or structuring the data contained in the resource.",
+          "help": "The participant responsible for entering, re-typing, and/or structuring the data contained in the resource.",
           "type": [
             "Person"
           ],
@@ -463,7 +463,7 @@
           "id": "https://w3id.org/ldac/terms#depositor",
           "name": "ldac:depositor",
           "label": "depositor",
-          "help": "The participant was responsible for depositing the resource in an archive.",
+          "help": "The participant responsible for depositing the resource in an archive.",
           "type": [
             "Person"
           ],
@@ -483,7 +483,7 @@
           "id": "https://w3id.org/ldac/terms#editor",
           "name": "ldac:editor",
           "label": "editor",
-          "help": "This role includes anyone whose role was editorial in nature, such as proofreaders, debuggers, testers, etc. It may overlap the Compiler role in some cases.",
+          "help": "Anyone whose role was editorial in nature, such as proofreaders, debuggers, testers, etc. It may overlap the Compiler role in some cases.",
           "type": [
             "Person"
           ],
@@ -523,7 +523,7 @@
           "id": "https://w3id.org/ldac/terms#participant",
           "name": "ldac:participant",
           "label": "participant",
-          "help": "This role is intended for minor participants such as audience members or other peripherally-involved participants in the event. These interlocutors need not have been physically present.",
+          "help": "Minor participants such as audience members or other peripherally-involved participants in the event. These interlocutors need not have been physically present.",
           "type": [
             "Person"
           ],
@@ -668,7 +668,7 @@
           "id": "http://purl.org/dc/terms/conformsTo",
           "name": "conformsTo",
           "label": "conformsTo",
-          "help": "A link to the Text Commons RO-Crate profile for collections.",
+          "help": "A link to the language data commons RO-Crate profile for collections.",
           "type": [
             "Select"
           ],
@@ -704,7 +704,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
-          "label": "Name",
+          "label": "name",
           "help": "The name of this collection.",
           "required": true,
           "multiple": false,
@@ -831,7 +831,7 @@
         {
           "id": "http://schema.org/holdingArchive",
           "name": "holdingArchive",
-          "label": "HoldingArchive",
+          "label": "holdingArchive",
           "help": "Organisation where the original of this work or collection is housed.",
           "multiple": false,
           "type": [
@@ -861,7 +861,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
-          "label": "Name",
+          "label": "name",
           "help": "The name of this work.",
           "required": true,
           "multiple": false,
@@ -941,7 +941,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
-          "label": "Name",
+          "label": "name",
           "help": "The name of this protocol.",
           "required": true,
           "multiple": false,

--- a/modes/language-data-commons-collection.json
+++ b/modes/language-data-commons-collection.json
@@ -227,7 +227,7 @@
         },
         {
           "id": "http://purl.org/dc/terms/rightsHolder",
-          "name": "rightsHolder",
+          "name": "dct:rightsHolder",
           "label": "rightsHolder",
           "help": "The person or organisation owning or managing rights over the resource.",
           "required": true,
@@ -379,7 +379,7 @@
         },
         {
           "id": "http://pcdm.org/models#hasMember",
-          "name": "hasMember",
+          "name": "pcdm:hasMember",
           "label": "hasMember",
           "help": "The sub-collections, if any, associated with this collection.",
           "type": [
@@ -410,7 +410,7 @@
         },
         {
           "id": "http://pcdm.org/models#memberOf",
-          "name": "memberOf",
+          "name": "pcdm:memberOf",
           "label": "memberOf",
           "help": "Links from a Repository Object or Collection to a containing Repository Object or Collection.",
           "multiple": true,
@@ -800,7 +800,7 @@
         },
         {
           "id": "http://pcdm.org/models#hasMember",
-          "name": "hasMember",
+          "name": "pcdm:hasMember",
           "label": "hasMember",
           "help": "The sub-collection.",
           "type": [
@@ -1069,7 +1069,7 @@
       "inputs": [
         {
           "id": "http://www.opengis.net/ont/geosparql#asWKT",
-          "name": "asWKT",
+          "name": "geosparql:asWKT",
           "label": "asWKT",
           "help": "The WKT serialisation of the geometry.",
           "required": true,
@@ -1162,15 +1162,6 @@
           "name": "encodingFormat",
           "label": "encodingFormat",
           "help": "The media type typically expressed using a MIME format.",
-          "type": [
-            "Text"
-          ]
-        },
-        {
-          "id": "https://purl.archive.org/language-data-commons/terms#size",
-          "name": "size",
-          "label": "size",
-          "help": "The size in bytes.",
           "type": [
             "Text"
           ]

--- a/modes/language-data-commons-collection.json
+++ b/modes/language-data-commons-collection.json
@@ -184,6 +184,7 @@
         {
           "id": "http://schema.org/isAccessibleForFree",
           "name": "isAccessibleForFree",
+          "label": "isAccessibleForFree",
           "help": "This is available under an Open Access license.",
           "required": false,
           "multiple": false,
@@ -215,7 +216,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#annotationOf",
-          "name": "annotationOf",
+          "name": "ldac:annotationOf",
+          "label": "annotationOf",
           "help": "This resource contains some kind of description that adds information to the resource it references.",
           "required": false,
           "multiple": true,
@@ -251,6 +253,7 @@
         {
           "id": "http://schema.org/creditText",
           "name": "creditText",
+          "label": "creditText",
           "help": "A free text bibliographic citation for this material, e.g. 'Cite as: Musgrave (2023). Title of work. DOI'.",
           "multiple": true,
           "type": [
@@ -270,6 +273,7 @@
         {
           "id": "http://schema.org/author",
           "name": "author",
+          "label": "author",
           "help": "The person or organisation responsible for creating this collection of data. Authors should be identified using URIs such as ORCiD or ROR.",
           "required": true,
           "type": [
@@ -281,6 +285,7 @@
         {
           "id": "http://schema.org/accountablePerson",
           "name": "accountablePerson",
+          "label": "accountablePerson",
           "help": "The person or organisation who is the data steward for this resource.",
           "required": true,
           "type": [
@@ -292,6 +297,7 @@
         {
           "id": "http://schema.org/publisher",
           "name": "publisher",
+          "label": "publisher",
           "help": "The organisation responsible for releasing this dataset.",
           "required": true,
           "type": [
@@ -302,6 +308,7 @@
         {
           "id": "http://schema.org/funder",
           "name": "funder",
+          "label": "funder",
           "help": "The organisation(s) responsible for funding the creation or collection of this dataset.",
           "type": [
             "Organization"
@@ -311,6 +318,7 @@
         {
           "id": "http://schema.org/citation",
           "name": "citation",
+          "label": "citation",
           "help": "Associated publications.",
           "type": [
             "CreativeWork"
@@ -320,6 +328,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "An abstract of the collection. Include as much detail as possible about the motivation and use of the dataset, including things that we do not yet have properties for.",
           "required": true,
           "type": [
@@ -329,7 +338,7 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#doi",
-          "name": "doi",
+          "name": "ldac:doi",
           "label": "DOI",
           "help": "A Digital Object Identifier, e.g. https://doi.org/10.1000/182.",
           "type": [
@@ -340,6 +349,7 @@
         {
           "id": "http://schema.org/temporalCoverage",
           "name": "temporalCoverage",
+          "label": "temporalCoverage",
           "help": "The range of years of creation for items in this dataset using a slash, e.g. 1900/1945. If there are sub-collections with different coverages put this on the sub-collections not the top-level.",
           "type": [
             "DateTime",
@@ -350,6 +360,7 @@
         {
           "id": "http://schema.org/spatialCoverage",
           "name": "spatialCoverage",
+          "label": "spatialCoverage",
           "help": "The place(s) that are the focus of the content. It is a sub-property of contentLocation intended primarily for more technical and detailed materials. For example, with a dataset, it indicates areas that the dataset describes: a dataset Cape York languages would have spatialCoverage which was the place: the outline of the Cape.",
           "type": [
             "Place"
@@ -359,6 +370,7 @@
         {
           "id": "http://schema.org/hasCollectionProtocol",
           "name": "hasCollectionProtocol",
+          "label": "hasCollectionProtocol",
           "help": "A link to a CollectionProtocol object with (at least) a summary of how resources were selected or elicited for this collection/sub-collection.",
           "type": [
             "CollectionProtocol"
@@ -368,6 +380,7 @@
         {
           "id": "http://pcdm.org/models#hasMember",
           "name": "hasMember",
+          "label": "hasMember",
           "help": "The sub-collections, if any, associated with this collection.",
           "type": [
             "RepositoryCollection"
@@ -377,6 +390,7 @@
         {
           "id": "http://schema.org/hasPart",
           "name": "hasPart",
+          "label": "hasPart",
           "help": "An item or CreativeWork that is part of this item, or CreativeWork (in some sense).",
           "type": [
             "File"
@@ -386,6 +400,7 @@
         {
           "id": "http://schema.org/isPartOf",
           "name": "isPartOf",
+          "label": "isPartOf",
           "help": "Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.",
           "multiple": true,
           "type": [
@@ -396,6 +411,7 @@
         {
           "id": "http://pcdm.org/models#memberOf",
           "name": "memberOf",
+          "label": "memberOf",
           "help": "Links from a Repository Object or Collection to a containing Repository Object or Collection.",
           "multiple": true,
           "type": [
@@ -405,7 +421,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#annotator",
-          "name": "annotator",
+          "name": "ldac:annotator",
+          "label": "annotator",
           "help": "The participant produced an annotation of this or a related resource.",
           "type": [
             "Person"
@@ -414,7 +431,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#compiler",
-          "name": "compiler",
+          "name": "ldac:compiler",
+          "label": "compiler",
           "help": "This refers to someone who creates a single resource with multiple parts, such as a book of short stories, or a person who produces a corpus of resources, which may be archived separately.",
           "type": [
             "Person"
@@ -423,7 +441,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#consultant",
-          "name": "consultant",
+          "name": "ldac:consultant",
+          "label": "consultant",
           "help": "This term is commonly used by field linguists for the native speakers who work with them in describing and analysing a language. They contribute their expertise in their native language to the resource, although their speech, sign, or writing may not appear directly in the resource. In some parts of the world, the preferred term for this role is 'informant'.",
           "type": [
             "Person"
@@ -432,7 +451,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#dataInputter",
-          "name": "dataInputter",
+          "name": "ldac:dataInputter",
+          "label": "dataInputter",
           "help": "The participant was responsible for entering, re-typing, and/or structuring the data contained in the resource.",
           "type": [
             "Person"
@@ -441,7 +461,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#depositor",
-          "name": "depositor",
+          "name": "ldac:depositor",
+          "label": "depositor",
           "help": "The participant was responsible for depositing the resource in an archive.",
           "type": [
             "Person"
@@ -450,7 +471,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#developer",
-          "name": "developer",
+          "name": "ldac:developer",
+          "label": "developer",
           "help": "A software programmer, designer, or analyst; a designer of a questionnaire or research task.",
           "type": [
             "Person"
@@ -459,7 +481,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#editor",
-          "name": "editor",
+          "name": "ldac:editor",
+          "label": "editor",
           "help": "This role includes anyone whose role was editorial in nature, such as proofreaders, debuggers, testers, etc. It may overlap the Compiler role in some cases.",
           "type": [
             "Person"
@@ -468,7 +491,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#illustrator",
-          "name": "illustrator",
+          "name": "ldac:illustrator",
+          "label": "illustrator",
           "help": "The participant contributed drawings or other illustrations to the resource.",
           "type": [
             "Person"
@@ -477,7 +501,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#interviewee",
-          "name": "interviewee",
+          "name": "ldac:interviewee",
+          "label": "interviewee",
           "help": "The participant was a respondent in an interview.",
           "type": [
             "Person"
@@ -486,7 +511,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#interviewer",
-          "name": "interviewer",
+          "name": "ldac:interviewer",
+          "label": "interviewer",
           "help": "The participant conducted an interview that forms part of the resource.",
           "type": [
             "Person"
@@ -495,7 +521,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#participant",
-          "name": "participant",
+          "name": "ldac:participant",
+          "label": "participant",
           "help": "This role is intended for minor participants such as audience members or other peripherally-involved participants in the event. These interlocutors need not have been physically present.",
           "type": [
             "Person"
@@ -504,7 +531,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#performer",
-          "name": "performer",
+          "name": "ldac:performer",
+          "label": "performer",
           "help": "It is recommended that this term be used only for creative participants whose role is not better indicated by a more specific term, such as 'speaker', 'signer', or 'singer'.",
           "type": [
             "Person"
@@ -513,7 +541,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#photographer",
-          "name": "photographer",
+          "name": "ldac:photographer",
+          "label": "photographer",
           "help": "The participant took the photograph, or shot the film, that appears in or constitutes the resource.",
           "type": [
             "Person"
@@ -522,7 +551,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#recorder",
-          "name": "recorder",
+          "name": "ldac:recorder",
+          "label": "recorder",
           "help": "The participant operated the recording machinery used to create the resource.",
           "type": [
             "Person"
@@ -531,7 +561,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#researcher",
-          "name": "researcher",
+          "name": "ldac:researcher",
+          "label": "researcher",
           "help": "The resource was created as part of the participant's research, or the research presents interim or final results from the participant's research.",
           "type": [
             "Person"
@@ -540,7 +571,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#researchParticipant",
-          "name": "researchParticipant",
+          "name": "ldac:researchParticipant",
+          "label": "researchParticipant",
           "help": "The participant acted as a research subject or responded to a questionnaire, the results of which study form the basis of the resource.",
           "type": [
             "Person"
@@ -549,7 +581,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#responder",
-          "name": "responder",
+          "name": "ldac:responder",
+          "label": "responder",
           "help": "This person's voice can be heard (or their words can be read) in the resource, typically saying the language-appropriate equivalent of \"uh-huh\", \"amen\", \"you don't say\", etc. This role is sometimes referred to as a \"yes-sayer\", \"backchanneler\", or \"co-conversant\".",
           "type": [
             "Person"
@@ -558,7 +591,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#signer",
-          "name": "signer",
+          "name": "ldac:signer",
+          "label": "signer",
           "help": "Those whose gestures predominate in a recorded or filmed resource. (This resource may be a transcription of that recording).",
           "type": [
             "Person"
@@ -567,7 +601,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#singer",
-          "name": "singer",
+          "name": "ldac:singer",
+          "label": "singer",
           "help": "The participant sang, either individually or as part of a group, in a resource that consists of a recording, a film, or a transcription of a recorded resource.",
           "type": [
             "Person"
@@ -576,7 +611,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#speaker",
-          "name": "speaker",
+          "name": "ldac:speaker",
+          "label": "speaker",
           "help": "Those whose voices predominate in a recorded or filmed resource. (This resource may be a transcription of that recording).",
           "type": [
             "Person"
@@ -585,7 +621,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#sponsor",
-          "name": "sponsor",
+          "name": "ldac:sponsor",
+          "label": "sponsor",
           "help": "The participant contributed financial support to the creation of the resource.",
           "type": [
             "Person"
@@ -594,7 +631,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#transcriber",
-          "name": "transcriber",
+          "name": "ldac:transcriber",
+          "label": "transcriber",
           "help": "The participant produced a transcription of this or a related resource.",
           "type": [
             "Person"
@@ -603,7 +641,8 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#translator",
-          "name": "translator",
+          "name": "ldac:translator",
+          "label": "translator",
           "help": "The participant produced a translation of this or a related resource.",
           "type": [
             "Person"
@@ -618,6 +657,7 @@
         {
           "id": "http://schema.org/contentLocation",
           "name": "contentLocation",
+          "label": "contentLocation",
           "help": "The location depicted or described in the content. For example, the location in a photograph or painting.",
           "type": [
             "Place"
@@ -627,13 +667,14 @@
         {
           "id": "http://purl.org/dc/terms/conformsTo",
           "name": "conformsTo",
+          "label": "conformsTo",
           "help": "A link to the Text Commons RO-Crate profile for collections.",
           "type": [
             "Select"
           ],
           "values": [
             {
-              "@id": "https://purl.archive.org/language-data-commons/profile#Collection"
+              "@id": "https://w3id.org/ldac/profile#Collection"
             }
           ],
           "multiple": false
@@ -651,7 +692,7 @@
         },
         {
           "id": "https://w3id.org/ldac/terms#subjectLanguage",
-          "name": "subjectLanguage",
+          "name": "ldac:subjectLanguage",
           "label": "subjectLanguage",
           "help": "The languages that the materials in the collection are about (not the language that it is in).",
           "type": [
@@ -674,6 +715,7 @@
         {
           "id": "http://schema.org/author",
           "name": "author",
+          "label": "author",
           "help": "The person or organisation responsible for creating this collection of data. Authors should be identified using URIs such as ORCiD or ROR.",
           "type": [
             "Person",
@@ -684,6 +726,7 @@
         {
           "id": "http://schema.org/accountablePerson",
           "name": "accountablePerson",
+          "label": "accountablePerson",
           "help": "The person or organisation who is the data steward for this resource.",
           "required": true,
           "type": [
@@ -695,6 +738,7 @@
         {
           "id": "http://schema.org/funder",
           "name": "funder",
+          "label": "funder",
           "help": "The organisation(s) responsible for funding the creation or collection of this data.",
           "type": [
             "Organization"
@@ -704,6 +748,7 @@
         {
           "id": "http://schema.org/citation",
           "name": "citation",
+          "label": "citation",
           "help": "Associated publications.",
           "type": [
             "CreativeWork"
@@ -725,6 +770,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "A description of the collection.",
           "type": [
             "TextArea"
@@ -734,6 +780,7 @@
         {
           "id": "http://schema.org/temporalCoverage",
           "name": "temporalCoverage",
+          "label": "temporalCoverage",
           "help": "The range of years of creation for items in this collection using a slash, e.g. 1900/1945. If there are sub-collections with different coverages put this on the sub-collections not the top-level.",
           "type": [
             "DateTime",
@@ -744,6 +791,7 @@
         {
           "id": "http://schema.org/hasCollectionProtocol",
           "name": "hasCollectionProtocol",
+          "label": "hasCollectionProtocol",
           "help": "A link to a CollectionProtocol object with (at least) a summary of how resources were selected or elicited for this collection/sub-collection.",
           "type": [
             "CollectionProtocol"
@@ -753,6 +801,7 @@
         {
           "id": "http://pcdm.org/models#hasMember",
           "name": "hasMember",
+          "label": "hasMember",
           "help": "The sub-collection.",
           "type": [
             "RepositoryCollection"
@@ -762,6 +811,7 @@
         {
           "id": "http://schema.org/dateCreated",
           "name": "dateCreated",
+          "label": "dateCreated",
           "help": "The (earliest) date the data in this dataset were created.",
           "type": [
             "Date"
@@ -770,7 +820,8 @@
         }, 
         {
           "id": "https://w3id.org/ldac/terms#dateFreeText",
-          "name": "dateFreeText",
+          "name": "ldac:dateFreeText",
+          "label": "dateFreeText",
           "help": "Date information which cannot be put in one of that standard date formats, e.g. 'mid-1970s', or it is not clear, for example if it is a creation or publication date.",
           "type": [
             "Text"
@@ -821,6 +872,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "An abstract of the work.",
           "type": [
             "TextArea"
@@ -830,6 +882,7 @@
         {
           "id": "http://schema.org/author",
           "name": "author",
+          "label": "author",
           "help": "The person or organisation responsible for creating this work. Authors should be identified using URIs such as ORCiD or ROR.",
           "type": [
             "Text",
@@ -841,6 +894,7 @@
         {
           "id": "http://schema.org/datePublished",
           "name": "datePublished",
+          "label": "datePublished",
           "help": "The (earliest) date this work was created.",
           "type": [
             "Date"
@@ -851,6 +905,7 @@
         {
           "id": "http://schema.org/publisher",
           "name": "publisher",
+          "label": "publisher",
           "help": "The organisation that published this work.",
           "type": [
             "Text",
@@ -861,6 +916,7 @@
         {
           "id": "http://schema.org/isbn",
           "name": "isbn",
+          "label": "ISBN",
           "help": "The ISBN for this work, if applicable.",
           "type": [
             "Text"
@@ -870,6 +926,7 @@
         {
           "id": "http://schema.org/issn",
           "name": "issn",
+          "label": "ISSN",
           "help": "The ISSN for this publication.",
           "type": [
             "Text"
@@ -895,6 +952,7 @@
         {
           "id": "http://schema.org/author",
           "name": "author",
+          "label": "author",
           "help": "The person or organisation responsible for creating this collection of data. Authors should be identified using URIs such as ORCiD or ROR.",
           "required": true,
           "type": [
@@ -906,6 +964,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "A summary of the collection protocol used for this collection or sub-collection, e.g. how texts were selected, or what prompts were given to participants.",
           "type": [
             "TextArea"
@@ -915,26 +974,27 @@
         {
           "id": "http://purl.archive.org/language-data-commons/terms#CollectionProtocolType",
           "name": "collectionProtocolType",
+          "label": "collectionProtocolType",
           "help": "The kind of collection protocol this is.",
           "type": [
             "SelectObject"
           ],
           "values": [
             {
-              "@id": "txc:ElicitationTask",
+              "@id": "ldac:ElicitationTask",
               "@type": "DefinedTerm",
               "description": "The collection protocol includes a task-based prompt to participants.",
               "inDefinedTermSet": {
-                "@id": "txc:CollectionProtocolTypeTerms"
+                "@id": "ldac:CollectionProtocolTypeTerms"
               },
               "name": "ElicitationTask"
             },
             {
-              "@id": "txc:TextSelectionCriteria",
+              "@id": "ldac:TextSelectionCriteria",
               "@type": "DefinedTerm",
               "description": "A description of the criteria used to select texts in a collection.",
               "inDefinedTermSet": {
-                "@id": "txc:CollectionProtocolTypeTerms"
+                "@id": "ldac:CollectionProtocolTypeTerms"
               },
               "name": "TextSelectionCriteria"
             }
@@ -944,6 +1004,7 @@
         {
           "id": "http://schema.org/datePublished",
           "name": "datePublished",
+          "label": "datePublished",
           "help": "The (earliest) date the collection protocol was published.",
           "type": [
             "Date"
@@ -959,6 +1020,7 @@
         {
           "id": "http://schema.org/name",
           "name": "name",
+          "label": "name",
           "help": "The name of the place.",
           "required": true,
           "multiple": false,
@@ -969,6 +1031,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "A description of the place.",
           "multiple": false,
           "type": [
@@ -978,6 +1041,7 @@
         {
           "id": "http://schema.org/address",
           "name": "address",
+          "label": "address",
           "help": "The physical address of the place.",
           "required": false,
           "multiple": true,
@@ -988,6 +1052,7 @@
         {
           "id": "http://schema.org/geo",
           "name": "geo",
+          "label": "geo",
           "help": "The geo-coordinates of the place.",
           "required": false,
           "multiple": true,
@@ -1005,6 +1070,7 @@
         {
           "id": "http://www.opengis.net/ont/geosparql#asWKT",
           "name": "asWKT",
+          "label": "asWKT",
           "help": "The WKT serialisation of the geometry.",
           "required": true,
           "multiple": true,
@@ -1032,6 +1098,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "Add any additional information not covered by other properties here.",
           "type": [
             "TextArea"
@@ -1068,6 +1135,7 @@
         {
           "id": "http://schema.org/description",
           "name": "description",
+          "label": "description",
           "help": "A description of the organisation.",
           "type": [
             "TextArea"
@@ -1077,6 +1145,7 @@
         {
           "id": "http://schema.org/location",
           "name": "location",
+          "label": "location",
           "help": "A location for the organisation, e.g. a city for a publisher.",
           "type": [
             "Text"
@@ -1091,6 +1160,7 @@
         {
           "id": "http://schema.org/encodingFormat",
           "name": "encodingFormat",
+          "label": "encodingFormat",
           "help": "The media type typically expressed using a MIME format.",
           "type": [
             "Text"
@@ -1099,14 +1169,16 @@
         {
           "id": "https://purl.archive.org/language-data-commons/terms#size",
           "name": "size",
+          "label": "size",
           "help": "The size in bytes.",
           "type": [
             "Text"
           ]
         },
         {
-          "id": "https://purl.archive.org/language-data-commons/terms#communicationMode",
+          "id": "https://w3id.org/ldac/terms#communicationMode",
           "name": "communicationMode",
+          "label": "communicationMode",
           "help": "The mode(s) (spoken, written, signed, etc.) used in the interaction represented by this resource.",
           "type": [
             "Text"

--- a/test/generate_spec.spec.js
+++ b/test/generate_spec.spec.js
@@ -28,9 +28,9 @@ describe("generateSpec", function () {
         fs.writeFileSync("test-ldac-profile.md", result)
 
         assert(result.match(`-  MUST have at least the following types: ."Dataset","RepositoryCollection".`))
-        assert(result.match(`-  MUST have a conformsTo property with least the following values .*{"@id":"https://purl.archive.org/language-data-commons/profile#Collection"}.`))
+        assert(result.match(`-  MUST have a conformsTo property with least the following values .*{"@id":"https://w3id.org/ldac/profile#Collection"}.`))
        
-        assert(result.match(/\<a name='object-txc_ElicitationTask'\/\>/))
+        assert(result.match(/\<a name='object-ldac_ElicitationTask'\/\>/))
         assert(result.match(/.*###  Value ElicitationTask/))
         assert(result.match(/The collection protocol includes a task-based prompt to participants.*/))
 


### PR DESCRIPTION
Only applied to comprehensive-mode.json, language-data-commons-collection.json and default,json, but can be applied to others if needed.

Prefixes added:
- ldac:
- pcdm:
- dct:
- geosparql:

Putting in a PR, but if more updates are needed in other repos before this is pushed feel free to leave for now.